### PR TITLE
Add pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CHANGELOG
 include LICENSE 
+include pyproject.toml
 include README.txt
 include setup.py
 include tox.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools ~= 41.4', 'setuptools_scm ~= 3.3', 'wheel ~= 0.33.6']
+build-backend = 'setuptools.build_meta'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 # if you change the envlist, please update .travis.yml file as well
+minversion = 3.7.0
+isolated_build = true
 envlist=
   py{27,35,36}-pytest{31,40,latest}
   flakes


### PR DESCRIPTION
There are no wheels ATM for [1.1.0](https://pypi.org/project/pytest-forked/1.1.0/#files) or [1.1.1](https://pypi.org/project/pytest-forked/1.1.1/#files). That means `pip` needs to build one, and, since [this package uses `setup_requires`](https://github.com/pytest-dev/pytest-forked/blob/dd42fd1861201536f985be7075f8cd869e17179c/setup.py#L22), that means `easy_install` will be used to fetch `setuptools_scm`. That is a problem for our CI for embarrassing reasons. We do have an updated `pip`, though, so if there were a `pyproject.toml`, we could probably build successfully. So, here it is...

I would also appreciate it if someone would upload a wheel for the newest version(s). It looks like that was the intention anyways:
https://github.com/pytest-dev/pytest-forked/blob/dd42fd1861201536f985be7075f8cd869e17179c/.travis.yml#L30
(It doesn't look like that behaved correctly, though: https://travis-ci.org/pytest-dev/pytest-forked/jobs/596284457#L377)