### PR TITLE
Add compatibility with Pytest 5.4.0+

### DIFF
--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -71,13 +71,8 @@ def forked_run_report(item):
 
 
 def report_process_crash(item, result):
-    try:
-        from _pytest.compat import getfslineno
-    except ImportError:
-        # pytest<4.2
-        path, lineno = item._getfslineno()
-    else:
-        path, lineno = getfslineno(item)
+    from _pytest._code.source import getfslineno
+    path, lineno = getfslineno(item)
     info = ("%s:%s: running the test CRASHED with signal %d" %
             (path, lineno, result.signal))
     from _pytest import runner


### PR DESCRIPTION
'getfslineno' has been removed from 'compat' in Pytest \[0\].
However, that function was just the wrapper of
'_pytest._code.source.getfslineno'. The latter exists in Pytest
since, at least, 3.0.0.

\[0\]: https://github.com/pytest-dev/pytest/commit/9c7f1d9b3.

Fixes: https://github.com/pytest-dev/pytest-forked/issues/30