### PR TITLE
Upgrade the test matrix with newer envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,26 @@
-sudo: false
 language: python
 python:
+- '3.8'
 - '2.7'
-- '3.5'
-- '3.6'
 - '3.7'
+- '3.6'
+- '3.5'
 cache: pip
 install: pip install -U tox setuptools_scm
 env:
   matrix:
-  - TOXENV=py-pytest31
-  - TOXENV=py-pytest40
+  - TOXENV=py-pytest310
+  - TOXENV=py-pytest46
+  - TOXENV=py-pytest54
   - TOXENV=py-pytestlatest
 matrix:
+  exclude:
+  - python: '2.7'  # pytest 5+ does not support Python 2
+    env: TOXENV=py-pytest54
   include:
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=flakes
-  - python: '3.7'
+  - python: '3.8'
     env: TOXENV=readme
 
     # piggyback on existing build for releases

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.7.0
 isolated_build = true
 envlist=
-  py{27,35,36}-pytest{31,40,latest}
+  py{27,35,36,37,38}-pytest{310,46,54,latest}
   flakes
   readme
 
@@ -12,8 +12,9 @@ deps =
   pycmd
   # to avoid .eggs
   setuptools_scm
-  pytest31: pytest~=3.1
-  pytest40: pytest~=4.0
+  pytest310: pytest~=3.10
+  pytest46: pytest~=4.6
+  pytest54: pytest~=5.4
   pytestlatest: pytest
 platform=linux|darwin
 commands=


### PR DESCRIPTION
This change adds new pytest and Python versions to tox
and Travis CI configs.

* pytest 3.10
* pytest 4.6
* pytest 5.4

* Python 3.7
* Python 3.8