### PR TITLE
🔥 Drop unused AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,0 @@
-install:
-  - C:\Python35\python -m pip install tox setuptools_scm
-
-build: false  # Not a C# project, build stuff at the test step instead.
-
-test_script:
-  - C:\Python35\python -m tox


### PR DESCRIPTION
pytest-forked is not supported, nor tested under Windows.