### PR TITLE
Implement support for pytest 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,19 @@ env:
   - TOXENV=py-pytest310
   - TOXENV=py-pytest46
   - TOXENV=py-pytest54
+  - TOXENV=py-pytest60
   - TOXENV=py-pytestlatest
+  - TOXENV=py-pytestmaster
 matrix:
   exclude:
   - python: '2.7'  # pytest 5+ does not support Python 2
     env: TOXENV=py-pytest54
+  - python: '2.7'  # pytest 5+ does not support Python 2
+    env: TOXENV=py-pytest60
+  - python: '2.7'  # pytest 5+ does not support Python 2
+    env: TOXENV=py-pytestmaster
+  - python: '2.7'  # Same as pytest54 for Python 2
+    env: TOXENV=py-pytestlatest
   include:
   - python: '3.8'
     env: TOXENV=flakes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v1.3.0
+======
+
+* Add support for pytest 6 (issue #45 / PR #46)
+* Replace `@pytest.mark.tryfirst` with newer `@pytest.hookimpl` (PR #46)
+* Invoke `pytest_runtest_logstart` and `pytest_runtest_logfinish` hooks in `runtest_protocol` (issue #31 / PR #46)
+
 v1.2.0
 ======
 

--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -41,9 +41,12 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_protocol(item):
     if item.config.getvalue("forked") or item.get_closest_marker("forked"):
+        ihook = item.ihook
+        ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
         reports = forked_run_report(item)
         for rep in reports:
-            item.ihook.pytest_runtest_logreport(report=rep)
+            ihook.pytest_runtest_logreport(report=rep)
+        ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
         return True
 
 

--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -73,7 +73,7 @@ def forked_run_report(item):
 
 
 def report_process_crash(item, result):
-    from _pytest._code.source import getfslineno
+    from _pytest._code import getfslineno
     path, lineno = getfslineno(item)
     info = ("%s:%s: running the test CRASHED with signal %d" %
             (path, lineno, result.signal))

--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -38,7 +38,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
     )
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_protocol(item):
     if item.config.getvalue("forked") or item.get_closest_marker("forked"):
         reports = forked_run_report(item)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -9,9 +9,12 @@ def _divert_atexit(request, monkeypatch):
     import atexit
     atexit_fns = []
 
+    def atexit_register(func, *args, **kwargs):
+        atexit_fns.append(lambda: func(*args, **kwargs))
+
     def finish():
         while atexit_fns:
             atexit_fns.pop()()
 
-    monkeypatch.setattr(atexit, "register", atexit_fns.append)
+    monkeypatch.setattr(atexit, "register", atexit_register)
     request.addfinalizer(finish)

--- a/testing/test_xfail_behavior.py
+++ b/testing/test_xfail_behavior.py
@@ -112,6 +112,9 @@ def test_xfail(is_crashing, is_strict, testdir):
 
         import pytest
 
+        # The current implementation emits RuntimeWarning.
+        pytestmark = pytest.mark.filterwarnings('ignore:pytest-forked xfail')
+
         @pytest.mark.xfail(
             reason='The process gets terminated',
             strict={is_strict!s},
@@ -123,9 +126,5 @@ def test_xfail(is_crashing, is_strict, testdir):
         format(**locals())
     )
 
-    pytest_run_result = testdir.runpytest(
-        test_module,
-        '-ra',
-        '-p', 'no:warnings',  # the current implementation emits RuntimeWarning
-    )
+    pytest_run_result = testdir.runpytest(test_module, '-ra')
     pytest_run_result.stdout.fnmatch_lines(expected_lines)

--- a/testing/test_xfail_behavior.py
+++ b/testing/test_xfail_behavior.py
@@ -53,7 +53,7 @@ def test_xfail(is_crashing, is_strict, testdir):
     session_start_title = '*==== test session starts ====*'
     loaded_pytest_plugins = 'plugins: forked*'
     collected_tests_num = 'collected 1 item'
-    expected_progress = 'test_xfail.py {expected_letter!s}'.format(**locals())
+    expected_progress = 'test_xfail.py {expected_letter!s}*'.format(**locals())
     failures_title = '*==== FAILURES ====*'
     failures_test_name = '*____ test_function ____*'
     failures_test_reason = '[XPASS(strict)] The process gets terminated'

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,9 @@ deps =
   pytest310: pytest~=3.10
   pytest46: pytest~=4.6
   pytest54: pytest~=5.4
+  pytest60: pytest~=6.0rc1
   pytestlatest: pytest
+  pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
 platform=linux|darwin
 commands=
   pytest {posargs}


### PR DESCRIPTION
This PR makes the testsuite pass when run against pytest 6 master (will be pytest 6.0.0).

The first two commits fix #45, by @The-Compiler.

Third commit just changes `@pytest.mark.tryfirst` -> `@pytest.hookimpl` because it is the modern way to do it (supported since pytest 2.8.0 I think so should be fine).

Fourth commit fixes #31. This is needed anyway, but a pytest commit https://github.com/pytest-dev/pytest/commit/796fba67880c9ce2011d4183dd574339e26618fa made it necessary for the tests here to pass.

Fifth commit changes how the RuntimeWarning is ignored otherwise its out is interleaved with pytest's output which makes the matching fail.

Last commit adds `tox -e pytestmaster` for easy testing of pytest master. I haven't added it to CI, as it might be unstable, but let me know if this is something you want. Didn't add pytest 6 to CI either, didn't want to add a prerelease.