### PR TITLE
Add support for Python 3.10, drop EOL 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+- '3.10-dev'
 - '3.9'
 - '3.8'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - TOXENV=py-pytest310
   - TOXENV=py-pytest46
   - TOXENV=py-pytest54
-  - TOXENV=py-pytest60
+  - TOXENV=py-pytest62
   - TOXENV=py-pytestlatest
   - TOXENV=py-pytestmaster
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
+- '3.9'
 - '3.8'
-- '2.7'
 - '3.7'
 - '3.6'
-- '3.5'
 cache: pip
 install: pip install -U tox setuptools_scm
 env:
@@ -16,15 +15,6 @@ env:
   - TOXENV=py-pytestlatest
   - TOXENV=py-pytestmaster
 matrix:
-  exclude:
-  - python: '2.7'  # pytest 5+ does not support Python 2
-    env: TOXENV=py-pytest54
-  - python: '2.7'  # pytest 5+ does not support Python 2
-    env: TOXENV=py-pytest60
-  - python: '2.7'  # pytest 5+ does not support Python 2
-    env: TOXENV=py-pytestmaster
-  - python: '2.7'  # Same as pytest54 for Python 2
-    env: TOXENV=py-pytestlatest
   include:
   - python: '3.8'
     env: TOXENV=flakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - TOXENV=py-pytest54
   - TOXENV=py-pytest62
   - TOXENV=py-pytestlatest
-  - TOXENV=py-pytestmaster
+  - TOXENV=py-pytestmain
 matrix:
   include:
   - python: '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     install_requires=['py', 'pytest>=3.10'],
     setup_requires=['setuptools_scm'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 7 - Inactive',
         'Framework :: Pytest',
@@ -33,12 +33,11 @@ setup(
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Utilities',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
     ],
 )

--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -71,7 +71,7 @@ def forked_run_report(item):
         return [runner.TestReport(**x) for x in report_dumps]
     else:
         if result.exitstatus == EXITSTATUS_TESTEXIT:
-            pytest.exit("forked test item %s raised Exit" % (item,))
+            pytest.exit(f"forked test item {item} raised Exit")
         return [report_process_crash(item, result)]
 
 

--- a/testing/test_xfail_behavior.py
+++ b/testing/test_xfail_behavior.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for xfail support."""
 import os
 import signal

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
   pytest310: pytest~=3.10
   pytest46: pytest~=4.6
   pytest54: pytest~=5.4
-  pytest60: pytest~=6.0rc1
+  pytest62: pytest~=6.2
   pytestlatest: pytest
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
 platform=linux|darwin

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.7.0
 isolated_build = true
 envlist=
-  py{27,35,36,37,38}-pytest{310,46,54,latest}
+  py{36,37,38,39}-pytest{310,46,54,latest}
   flakes
   build-dists
   metadata-validation

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.7.0
 isolated_build = true
 envlist=
-  py{36,37,38,39,310}-pytest{310,46,54,latest}
+  py{36,37,38,39,310}-pytest{310,46,54,62,latest}
   flakes
   build-dists
   metadata-validation

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
   pytest54: pytest~=5.4
   pytest62: pytest~=6.2
   pytestlatest: pytest
-  pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
+  pytestmain: git+https://github.com/pytest-dev/pytest.git@main
 platform=linux|darwin
 commands=
   pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.7.0
 isolated_build = true
 envlist=
-  py{36,37,38,39}-pytest{310,46,54,latest}
+  py{36,37,38,39,310}-pytest{310,46,54,latest}
   flakes
   build-dists
   metadata-validation


### PR DESCRIPTION
And:

* Upgrade Python syntax with `pyupgrade --py36-plus`
* Bump testing pytest 6.0 to 6.2, switch `pytestmaster` to `pytestmain`
* Add support for Python 3.10 (release candidate out now, final due in October)
