### PR TITLE
pyproject.toml: Relax requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ['setuptools ~= 41.4', 'setuptools_scm ~= 3.3', 'wheel ~= 0.33.6']
+requires = ['setuptools >= 41.4', 'setuptools_scm >= 3.3', 'wheel >= 0.33.6']
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
These tight requirements seem to have been unnecessary.

Fixes #77.