### PR TITLE
Fix test failure if multiple pytest plugins are installed

### DIFF
--- a/testing/test_xfail_behavior.py
+++ b/testing/test_xfail_behavior.py
@@ -50,7 +50,7 @@ def test_xfail(is_crashing, is_strict, testdir):
         expected_word = "XPASS"
 
     session_start_title = "*==== test session starts ====*"
-    loaded_pytest_plugins = "plugins: forked*"
+    loaded_pytest_plugins = "plugins:* forked*"
     collected_tests_num = "collected 1 item"
     expected_progress = f"test_xfail.py {expected_letter!s}*"
     failures_title = "*==== FAILURES ====*"


### PR DESCRIPTION
Dependencies can sometimes cause extra pytest plugins to be installed while running tests: for example, in current Debian, py → pkg-resources → inflect → typeguard includes one.  The order of plugins that pytest displays on the `plugins:` line of its output doesn't appear to be defined, so tolerate variation.