### PR TITLE
Modernize Python versions and CI infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,23 +10,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - python: "3.7"
-            tox_env: "py37"
-          - python: "3.8"
-            tox_env: "py38"
-          - python: "3.9"
-            tox_env: "py39"
           - python: "3.10"
             tox_env: "py310"
           - python: "3.11"
             tox_env: "py311"
+          - python: "3.12"
+            tox_env: "py312"
+          - python: "3.13"
+            tox_env: "py313"
+          - python: "3.14"
+            tox_env: "py314"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox
@@ -40,6 +40,6 @@ jobs:
   check-package:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Check Package
-      uses: hynek/build-and-inspect-python-package@v1.5
+      uses: hynek/build-and-inspect-python-package@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+* Drop support for EOL Python versions: 3.7, 3.8, 3.9.
+
 v1.6.0
 ======
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     zip_safe=False,
     install_requires=["py", "pytest>=3.10"],
     setup_requires=["setuptools_scm"],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 7 - Inactive",
         "Framework :: Pytest",
@@ -34,11 +34,11 @@ setup(
         "Topic :: Utilities",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.7.0
 isolated_build = true
 envlist=
-  py{37,38,39,310,311}-pytest{310,46,54,62,latest}
+  py{310,311,312,313,314}-pytest{310,46,54,62,latest}
   flakes
   build-dists
   metadata-validation


### PR DESCRIPTION
Drop EOL Pythons and add up to 3.14.