### PR TITLE
Improve crash message: distinguish exit vs signal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ UNRELEASED
 ==========
 
 * Drop support for EOL Python versions: 3.7, 3.8, 3.9.
+* Print proper child process exit status.
 
 v1.6.0
 ======

--- a/src/pytest_forked/__init__.py
+++ b/src/pytest_forked/__init__.py
@@ -83,13 +83,23 @@ def forked_run_report(item):
 
 def report_process_crash(item, result):
     from _pytest._code import getfslineno
+    import signal as signal_module
 
     path, lineno = getfslineno(item)
-    info = "%s:%s: running the test CRASHED with signal %d" % (
-        path,
-        lineno,
-        result.signal,
-    )
+    if result.signal:
+        sig_name = signal_module.Signals(result.signal).name
+        info = "%s:%s: running the test CRASHED with signal %d (%s)" % (
+            path,
+            lineno,
+            result.signal,
+            sig_name,
+        )
+    else:
+        info = "%s:%s: running the test EXITED with status %d" % (
+            path,
+            lineno,
+            result.exitstatus,
+        )
     from _pytest import runner
 
     # pytest >= 4.1

--- a/testing/test_boxed.py
+++ b/testing/test_boxed.py
@@ -67,6 +67,32 @@ def test_functional_boxed_capturing(testdir, capmode):
     )
 
 
+@needsfork
+def test_crash_message_shows_signal_name(testdir):
+    p1 = testdir.makepyfile(
+        """
+        import os, signal
+        def test_function():
+            os.kill(os.getpid(), signal.SIGTERM)
+    """
+    )
+    result = testdir.runpytest(p1, "--forked")
+    result.stdout.fnmatch_lines(["*CRASHED with signal 15 (SIGTERM)*", "*1 failed*"])
+
+
+@needsfork
+def test_crash_message_shows_exit_status(testdir):
+    p1 = testdir.makepyfile(
+        """
+        import os
+        def test_function():
+            os._exit(42)
+    """
+    )
+    result = testdir.runpytest(p1, "--forked")
+    result.stdout.fnmatch_lines(["*EXITED with status 42*", "*1 failed*"])
+
+
 def test_is_not_boxed_by_default(testdir):
     config = testdir.parseconfig(testdir.tmpdir)
     assert not config.option.forked

--- a/testing/test_xfail_behavior.py
+++ b/testing/test_xfail_behavior.py
@@ -69,7 +69,7 @@ def test_xfail(is_crashing, is_strict, testdir):
     reason_string = (
         f"reason: The process gets terminated; "
         f"pytest-forked reason: "
-        f"*:*: running the test CRASHED with signal {sig_num:d}"
+        f"*:*: running the test CRASHED with signal {sig_num:d}*"
     )
     if expected_lowercase == "xfailed" and PYTEST_GTE_7_2:
         short_test_summary += " - " + reason_string


### PR DESCRIPTION
When a forked test process exits with a non-zero exit code (signal == 0), the message previously said "CRASHED with signal 0" which is misleading — signal 0 is not a real signal and the process was not killed by one.

Now:
- Non-signal exit: "EXITED with status <N>"
- Signal kill:     "CRASHED with signal <N> (<NAME>)" e.g. "signal 11 (SIGSEGV)"

signal.Signals() is called without a try/except because result.signal comes from os.WTERMSIG(), which extracts the signal from the kernel's wait status — the kernel can only kill a process with a valid signal number.

Note: sys.exit() is caught by pytest as SystemExit and does not trigger report_process_crash; os._exit() bypasses the marshal pipe and does.